### PR TITLE
Add: permissions styling

### DIFF
--- a/resources/views/Admin/index.blade.php
+++ b/resources/views/Admin/index.blade.php
@@ -4,9 +4,6 @@
             {{ __('Admin') }}
         </h2>
     </x-slot>
-    <form method="GET" action="{{ route('admin.createNewUser') }}">
-        <x-primary-button>Create New User</x-primary-button>
-    </form>
     <div class="bg-stockhive-grey-dark text-white shadow-sm rounded-lg mt-8 lg:w-[85%] w-full m-auto p-4">
         <form method="GET" action="{{ route('admin.sort') }}" class="m-auto text-right w-[90%]">
             <select name="sort" id="sort" class="text-white bg-stockhive-grey hover:shadow-bxs hover:border-accent transition-all hover:ring-accent p-2 rounded-lg w-[50%]">
@@ -20,6 +17,9 @@
             @if($employees->isNotEmpty())
             <div class="flex justify-between items-center gap-8 my-4 border-grey bg-stockhive-grey rounded-lg p-4 border-2 m-auto w-[90%] text-right">
                 <x-paginate :items="$employees"/>
+                <form method="GET" action="{{ route('admin.createNewUser') }}">
+                    <x-primary-button>Create New User</x-primary-button>
+                </form>
             </div>
                 <table class="border-separate border-2 m-auto my-4 lg:w-[90%] w-full text-center border-grey hover:border-accent transition-all hover:shadow-bxs border-spacing-2 md:border-spacing-8 bg-stockhive-grey rounded-lg">
                     <thead>

--- a/resources/views/Admin/new-user.blade.php
+++ b/resources/views/Admin/new-user.blade.php
@@ -4,44 +4,53 @@
             {{ __('New User') }}
         </h2>
     </x-slot>
+    <div class="bg-stockhive-grey-dark text-white shadow-sm rounded-lg mt-8 lg:w-[85%] w-full m-auto p-4">
+    <h1 class="text-2xl font-bold text-center pb-4">Info:</h1>
     <form action="{{ route('admin.addNewUser') }}" method="POST">
         @csrf
-        <h2>First Name:</h2>
-        <input type="text" name="first_name">
-        <h2>Last Name:</h2>
-        <input type="text" name="last_name">
-        <h2>Email:</h2>
-        <input type="text" name="email">
-        <h2>Password:</h2>
-        <input type="password" name="password">
-        <h2>Roles</h2>
+        <div class="flex items-center space-x-2">
+            <h2>First Name:</h2>
+            <input type="text" class="bg-stockhive-grey rounded-lg text-white border-2 hover:shadow-bxs transition-all hover:border-accent" name="first_name">
+            <h2>Last Name:</h2>
+            <input type="text" class="bg-stockhive-grey rounded-lg text-white border-2 hover:shadow-bxs transition-all hover:border-accent" name="last_name">
+            <h2>Email:</h2>
+            <input type="text" class="bg-stockhive-grey rounded-lg text-white border-2 hover:shadow-bxs transition-all hover:border-accent" name="email">
+            <h2>Password:</h2>
+            <input type="password" class="bg-stockhive-grey rounded-lg text-white border-2 hover:shadow-bxs transition-all hover:border-accent"name="password">
+        </div>
+        <h1 class="text-2xl font-bold text-center py-8">Roles & Permissions:</h1>
             @csrf
-            <table>
-                <tr>
-                    <th>Role</th>
-                    <th>Permissions</th>
-                    <th>Active</th>
-                </tr>
+            <table class="border-separate border-2 m-auto my-4 lg:w-[90%] w-full text-center border-grey hover:border-accent transition-all hover:shadow-bxs border-spacing-2 md:border-spacing-8 bg-stockhive-grey rounded-lg">
+                <thead>
+                    <tr class="text-left border-b-2 border-grey">
+                        <th class="py-2 px-4 text-center">Role</th>
+                        <th class="py-2 px-4 text-center">Permissions</th>
+                        <th class="py-2 px-4 text-center">Active</th>
+                    </tr>
+                </thead>
                 @php
                     $roles = DB::select("SELECT * FROM role")
                 @endphp
-                @foreach ($roles as $role)
-                <tr>
-                    @php
-                    $permissions = DB::select("SELECT permission.name FROM role_permission, permission WHERE permission.id = role_permission.permission_id AND role_id = " . $role->id)
-                    @endphp
-                    <td>{{ $role->name }}</td>
-                    <td>
-                        @foreach ($permissions as $permission)
-                            <p>{{ $permission->name }}</p>
-                        @endforeach
-                    </td>
-                    <td>
-                        <input type="checkbox" name="roles[]" value="{{ $role->id }}">
-                    </td>
-                </tr>
-                @endforeach
+                <tbody>
+                    @foreach ($roles as $role)
+                    <tr class="hover:bg-stockhive-grey-light transition-all">
+                        @php
+                        $permissions = DB::select("SELECT permission.name FROM role_permission, permission WHERE permission.id = role_permission.permission_id AND role_id = " . $role->id)
+                        @endphp
+                        <td class="py-2 px-4">{{ $role->name }}</td>
+                        <td class="py-2 px-4">
+                            @foreach ($permissions as $permission)
+                                <p class="text-sm text-gray-600 bg-stockhive-grey-dark my-4 p-2 rounded-lg">{{ $permission->name }}</p>
+                            @endforeach
+                        </td>
+                        <td>
+                            <input type="checkbox" name="roles[]"  class="form-checkbox h-5 w-5 bg-stockhive-grey-dark text-accent rounded border-2" value="{{ $role->id }}">
+                        </td>
+                    </tr>
+                    @endforeach
+                </tbody>
             </table>
         <x-primary-button>Create User</x-primary-button>
     </form>
+</div>
 </x-app-layout>

--- a/resources/views/Admin/user.blade.php
+++ b/resources/views/Admin/user.blade.php
@@ -1,74 +1,82 @@
 <x-app-layout>
-    <form action="{{ route('admin.updateSettings') }}" method="POST">
-        @csrf
-        <h2>ID: {{ ($user['id']) }}</h2>
-        <h2>First Name:</h2>
-        <input type="text" name="first_name" value="{{ ($user['first_name']) }}">
-        <h2>Last Name:</h2>
-        <input type="text" name="last_name" value="{{ ($user['last_name']) }}">
-        <h2>Email:</h2>
-        <input type="text" name="email" value="{{ ($user['email']) }}">
-        <input type="hidden" name="id" value ="{{ $user['id'] }}">
-        <x-primary-button>Save Settings</x-primary-button>
-    </form>
-    <div>
-        <h2>Active Permissions:</h2>
+    <div class="bg-stockhive-grey-dark text-white shadow-sm rounded-lg mt-8 lg:w-[85%] w-full m-auto p-4">
+        <form action="{{ route('admin.updateSettings') }}" method="POST">
+            @csrf
+            <h1 class="text-xl">ID: {{ ($user['id']) }}</h1>
+            <div class="flex items-center space-x-4">
+                <h2>First Name:</h2>
+                <input type="text" class="bg-stockhive-grey rounded-lg text-white border-2 hover:shadow-bxs transition-all hover:border-accent" name="first_name" value="{{ ($user['first_name']) }}" class="form-input">
+                <h2>Last Name:</h2>
+                <input type="text" class="bg-stockhive-grey rounded-lg text-white border-2 hover:shadow-bxs transition-all hover:border-accent" name="last_name" value="{{ ($user['last_name']) }}" class="form-input">
+                <h2>Email:</h2>
+                <input type="text" class="bg-stockhive-grey rounded-lg text-white border-2 hover:shadow-bxs transition-all hover:border-accent" name="email" value="{{ ($user['email']) }}" class="form-input">
+                <input type="hidden" class="bg-stockhive-grey rounded-lg text-white border-2 hover:shadow-bxs transition-all hover:border-accent" name="id" value ="{{ $user['id'] }}">
+                <x-primary-button>Save Settings</x-primary-button>
+            </div>
+        </form>
+    </div>
+    <div class="bg-stockhive-grey-dark text-white shadow-sm rounded-lg mt-8 lg:w-[85%] w-full m-auto p-4">
+        <h1 class="text-2xl font-bold text-center">Active Permissions</h1>
         @php global $permissions; @endphp
         @include('components.get-permissions', ['id' => $user['id']])
 
         @foreach($permissions->groupBy('categoryName') as $category => $categoryPermissions)
-            <div>
-                <h3>{{ $category }}</h3>
-                <ul>
+            <div class="mt-4">
+                <h1 class="font-bold text-xl">{{ $category }}</h1>
+                <ul class="flex items-center space-x-4">
                     @foreach($categoryPermissions as $permission)
-                        <li>{{ $permission->id }} - {{ $permission->permissionName }}</li>
+                        <li class="text-sm text-gray-600 bg-stockhive-grey my-4 p-2 rounded-lg">{{ $permission->id }} - {{ $permission->permissionName }}</li>
                     @endforeach
                 </ul>
             </div>
         @endforeach
     </div>
-    <div>
+    <div class="bg-stockhive-grey-dark text-white shadow-sm rounded-lg mt-8 lg:w-[85%] w-full m-auto p-4">
         @if ($user['id'] == Auth::user()->id)
-        <h2>You cannot edit your own permissions</h2>
+        <h2 class="text-error">You cannot edit your own permissions</h2>
         @else
         <h2>Roles</h2>
         <form action="{{ route('admin.updatePermissions') }}" method="POST">
             @csrf
             <input type="hidden" name="id" value="{{ $user['id'] }}">
-            <table>
-                <tr>
-                    <th>Role</th>
-                    <th>Permissions</th>
-                    <th>Active</th>
-                </tr>
-                @php
-                    $roles = DB::select("SELECT *, CASE WHEN name IN (SELECT name FROM role, user_role WHERE role.id = user_role.role_id AND user_role.user_id = ?) THEN TRUE ELSE FALSE END AS isActive FROM role", [$user['id']])
-                @endphp
-                @foreach ($roles as $role)
-                <tr>
-                    @php
-                    $permissions = DB::select("SELECT permission.name FROM role_permission, permission WHERE permission.id = role_permission.permission_id AND role_id = " . $role->id)
-                    @endphp
-                    <td>{{ $role->name }}</td>
-                    <td>
-                        @foreach ($permissions as $permission)
-                            <p>{{ $permission->name }}</p>
-                        @endforeach
-                    </td>
-                    @php
-                        $checked = "";
-                        if ($role->isActive == 1) {
-                            $checked = "checked";
-                        }
-                    @endphp
-                    <td>
-                        <input type="checkbox" name="roles[]" value="{{ $role->id }}" {{$checked}}>
-                    </td>
-                </tr>
+            <table class="border-separate border-2 m-auto my-4 lg:w-[90%] w-full text-center border-grey hover:border-accent transition-all hover:shadow-bxs border-spacing-2 md:border-spacing-8 bg-stockhive-grey rounded-lg">
+    <thead>
+        <tr class="text-left border-b-2 border-grey">
+            <th class="py-2 px-4 text-center">Role</th>
+            <th class="py-2 px-4 text-center">Permissions</th>
+            <th class="py-2 px-4 text-center">Active</th>
+        </tr>
+    </thead>
+    <tbody>
+        @php
+            $roles = DB::select("SELECT *, CASE WHEN name IN (SELECT name FROM role, user_role WHERE role.id = user_role.role_id AND user_role.user_id = ?) THEN TRUE ELSE FALSE END AS isActive FROM role", [$user['id']])
+        @endphp
+        @foreach ($roles as $role)
+        <tr class="hover:bg-stockhive-grey-light transition-all">
+            @php
+            $permissions = DB::select("SELECT permission.name FROM role_permission, permission WHERE permission.id = role_permission.permission_id AND role_id = " . $role->id)
+            @endphp
+            <td class="py-2 px-4">{{ $role->name }}</td>
+            <td class="py-2 px-4">
+                @foreach ($permissions as $permission)
+                    <p class="text-sm text-gray-600 bg-stockhive-grey-dark my-4 p-2 rounded-lg">{{ $permission->name }}</p>
                 @endforeach
-            </table>
-            <x-primary-button>Update Permissions</x-primary-button>
+            </td>
+            @php
+                $checked = $role->isActive == 1 ? "checked" : "";
+            @endphp
+            <td class="py-2 px-4">
+                <input type="checkbox" name="roles[]" value="{{ $role->id }}" {{$checked}} class="form-checkbox h-5 w-5 text-blue-600 rounded">
+            </td>
+        </tr>
+        @endforeach
+    </tbody>
+</table>
+            <div class="lg:w-[90%] m-auto">
+                <x-primary-button>Update Permissions</x-primary-button>
+            </div>
         </form>
         @endif
     </div>
+    <br />
 </x-app-layout>

--- a/resources/views/Admin/user.blade.php
+++ b/resources/views/Admin/user.blade.php
@@ -55,7 +55,6 @@
         @if ($user['id'] == Auth::user()->id)
         <h2 class="text-error">You cannot edit your own permissions</h2>
         @else
-        <h2>Roles</h2>
         <form action="{{ route('admin.updatePermissions') }}" method="POST">
             @csrf
             <input type="hidden" name="id" value="{{ $user['id'] }}">

--- a/resources/views/Admin/user.blade.php
+++ b/resources/views/Admin/user.blade.php
@@ -14,26 +14,23 @@
                 <x-primary-button>Save Settings</x-primary-button>
             </div>
         </form>
-    </div>
-    <div class="bg-stockhive-grey-dark text-white shadow-sm rounded-lg mt-8 lg:w-[85%] w-full m-auto p-4">
-      <form action="{{ route('admin.toggleAccountActivation') }}">
-      @csrf
-      <input type="hidden" name="id" value="{{ $user['id'] }}">
-          <x-primary-button>
-              @php
-              if ($user['password'] == null) {
-                  echo "Activate Account";
-              }
-              else {
-                  echo "Deactivate Account";
-              }
-              @endphp
-          </x-primary-button>
-          @if ($user['password'] == null)
-              <p>Password</p>
-              <input type="password" name="password">
-          @endif
-      </form>
+        <form action="{{ route('admin.toggleAccountActivation') }}" method="POST">
+            @csrf
+            <input type="hidden" name="id" value="{{ $user['id'] }}">
+            <x-primary-button>
+            @php
+            if ($user['password'] == null) {
+                echo "Activate Account";
+            } else {
+                echo "Deactivate Account";
+            }
+            @endphp
+            </x-primary-button>
+            @if ($user['password'] == null)
+            <h2>Password</h2>
+            <input type="password" name="password" class="bg-stockhive-grey rounded-lg text-white border-2 hover:shadow-bxs transition-all hover:border-accent">
+            @endif
+        </form>
     </div>
     <div class="bg-stockhive-grey-dark text-white shadow-sm rounded-lg mt-8 lg:w-[85%] w-full m-auto p-4">
         <h1 class="text-2xl font-bold text-center">Active Permissions</h1>
@@ -85,7 +82,7 @@
                 $checked = $role->isActive == 1 ? "checked" : "";
             @endphp
             <td class="py-2 px-4">
-                <input type="checkbox" name="roles[]" value="{{ $role->id }}" {{$checked}} class="form-checkbox h-5 w-5 text-blue-600 rounded">
+                <input type="checkbox" name="roles[]" value="{{ $role->id }}" {{$checked}} class="form-checkbox h-5 w-5 bg-stockhive-grey-dark text-accent rounded border-2">
             </td>
         </tr>
         @endforeach

--- a/resources/views/StockManager/index.blade.php
+++ b/resources/views/StockManager/index.blade.php
@@ -13,7 +13,6 @@
             </select>
             <input type="hidden" name="page" value="{{ request('page', 1) }}"> <!-- Get page number, default to 1 if none set. -->
             <x-primary-button class="ml-4">Sort</x-primary-button>
-            <x-get-permissions/>
         </form>
         <form action="{{ route('stock-management.chosenItems') }}" method="POST">
             @csrf

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,6 +22,7 @@ export default {
             'white': '#ffffff',
             'black': '#000000',
             'grey': '#4b5563',
+            'error': '#e3342f',
         },
         boxShadow: {
             'bxs': "0 0 10px #F9B339",


### PR DESCRIPTION
This pull request includes significant updates to the `resources/views/Admin/user.blade.php` and a minor change to `resources/views/StockManager/index.blade.php`. The main focus is on enhancing the user interface and improving the overall styling and layout of the admin user settings and permissions page.

### Enhancements to Admin User Settings and Permissions Page:

* Added new container divs with `bg-stockhive-grey-dark`, `text-white`, `shadow-sm`, and `rounded-lg` classes to improve the visual layout and styling of the user settings form and permissions sections.
* Updated input fields and buttons with additional classes for better styling, including `bg-stockhive-grey`, `rounded-lg`, `text-white`, `border-2`, `hover:shadow-bxs`, `transition-all`, and `hover:border-accent`.
* Enhanced the table for roles and permissions with new classes for better spacing, borders, and hover effects, such as `border-separate`, `border-2`, `m-auto`, `my-4`, `lg:w-[90%]`, `w-full`, `text-center`, `border-grey`, `hover:border-accent`, `transition-all`, `hover:shadow-bxs`, `border-spacing-2`, `md:border-spacing-8`, `bg-stockhive-grey`, and `rounded-lg`.
* Improved the layout of permissions list items with new classes for better readability and styling, including `text-sm`, `text-gray-600`, `bg-stockhive-grey`, `my-4`, `p-2`, and `rounded-lg`.
* Added new headings and text styles to improve the readability and structure of the page, such as `text-xl`, `font-bold`, `text-center`, `text-2xl`, and `text-error`.

### Minor Change to Stock Manager Page:

* Removed the `<x-get-permissions/>` component call from the stock manager index page form.